### PR TITLE
merge upstream `2.14-stable` changes into Braze's fork

### DIFF
--- a/.evergreen/config-atlas.yml
+++ b/.evergreen/config-atlas.yml
@@ -604,6 +604,14 @@ axes:
         variables:
           FORK: '1'
 
+  - id: solo
+    display_name: Solo
+    values:
+      - id: on
+        display_name: On
+        variables:
+          SOLO: '1'
+
   - id: "as"
     display_name: ActiveSupport
     values:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -116,6 +116,7 @@ functions:
             export MMAPV1="${MMAPV1}"
             export FLE="${FLE}"
             export FORK="${FORK}"
+            export SOLO="${SOLO}"
             export EXTRA_URI_OPTIONS="${EXTRA_URI_OPTIONS}"
 
             export STRESS="${STRESS}"
@@ -643,6 +644,14 @@ axes:
         variables:
           FORK: '1'
 
+  - id: solo
+    display_name: Solo
+    values:
+      - id: on
+        display_name: On
+        variables:
+          SOLO: '1'
+
   - id: "as"
     display_name: ActiveSupport
     values:
@@ -934,6 +943,17 @@ buildvariants:
       topology: '*'
       os: ubuntu1604
     display_name: "${mongodb-version} ${topology} fork ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
+  - matrix_name: "solo"
+    matrix_spec:
+      solo: on
+      ruby: [ruby-2.7, ruby-2.6, ruby-2.5, ruby-2.4, ruby-2.3, jruby-9.2]
+      mongodb-version: ["4.4"]
+      topology: '*'
+      os: ubuntu1604
+    display_name: "${mongodb-version} ${topology} solo ${ruby}"
     tasks:
       - name: "test-mlaunch"
 

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -225,6 +225,14 @@ axes:
         variables:
           FORK: '1'
 
+  - id: solo
+    display_name: Solo
+    values:
+      - id: on
+        display_name: On
+        variables:
+          SOLO: '1'
+
   - id: "as"
     display_name: ActiveSupport
     values:

--- a/.evergreen/config/common.yml.erb
+++ b/.evergreen/config/common.yml.erb
@@ -170,6 +170,7 @@ functions:
             export MMAPV1="${MMAPV1}"
             export FLE="${FLE}"
             export FORK="${FORK}"
+            export SOLO="${SOLO}"
             export EXTRA_URI_OPTIONS="${EXTRA_URI_OPTIONS}"
 
             export STRESS="${STRESS}"

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -176,6 +176,17 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
+  - matrix_name: "solo"
+    matrix_spec:
+      solo: on
+      ruby: [ruby-2.7, ruby-2.6, ruby-2.5, ruby-2.4, ruby-2.3, jruby-9.2]
+      mongodb-version: ["4.4"]
+      topology: '*'
+      os: ubuntu1604
+    display_name: "${mongodb-version} ${topology} solo ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
   - matrix_name: "stress"
     matrix_spec:
       stress: on

--- a/.evergreen/functions-config.sh
+++ b/.evergreen/functions-config.sh
@@ -45,6 +45,9 @@ show_local_instructions() {
   if test -n "$FORK"; then
     params="$params FORK=$FORK"
   fi
+  if test -n "$SOLO"; then
+    params="$params SOLO=$SOLO"
+  fi
   if test -n "$OCSP_ALGORITHM"; then
     params="$params OCSP_ALGORITHM=$OCSP_ALGORITHM"
   fi

--- a/.evergreen/functions.sh
+++ b/.evergreen/functions.sh
@@ -241,9 +241,11 @@ bundle_install() {
 }
 
 kill_jruby() {
+  set +o pipefail
   jruby_running=`ps -ef | grep 'jruby' | grep -v grep | awk '{print $2}'`
+  set -o pipefail
   if [ -n "$jruby_running" ];then
     echo "terminating remaining jruby processes"
-    for pid in $(ps -ef | grep "jruby" | grep -v grep | awk '{print $2}'); do kill -9 $pid; done
+    for pid in $jruby_running; do kill -9 $pid; done
   fi
 }

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -63,6 +63,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
       /tutorials/ruby-driver-authentication
       /tutorials/user-management
       /tutorials/ruby-driver-crud-operations
+      /tutorials/ruby-driver-bulk-operations
       /tutorials/ruby-driver-collection-tasks
       /tutorials/ruby-driver-projections
       /tutorials/ruby-driver-sessions
@@ -73,7 +74,6 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
       /tutorials/ruby-driver-indexing
       /tutorials/ruby-driver-collations
       /tutorials/ruby-driver-aggregation
-      /tutorials/ruby-driver-bulk-operations
       /tutorials/ruby-driver-text-search
       /tutorials/ruby-driver-geospatial-search
       /tutorials/ruby-driver-gridfs

--- a/docs/tutorials/ruby-driver-bulk-operations.txt
+++ b/docs/tutorials/ruby-driver-bulk-operations.txt
@@ -1,6 +1,6 @@
-***************
-Bulk Operations
-***************
+***********
+Bulk Writes
+***********
 
 .. default-domain:: mongodb
 
@@ -14,18 +14,65 @@ Bulk Operations
 
 The bulk write API sends several write operations to the server in a single
 command. Use the bulk write API to reduce the number of network round-trips
-when performing several writes at a time.
+when performing several writes at a time. For example, to efficiently perform
+multiple updates, one might do:
 
-If the ``ordered`` option is set to ``true`` (which is the default),
-the operations are applied in order and if any operation fails, subsequent
-operations are not attempted. If the ``ordered`` option is set to ``false``,
-all specified operations are attempted.
+.. code-block:: ruby
 
-The ``bulk_write`` method takes three arguments:
+  collection = client['colors']
+  collection.bulk_write([
+    {
+      update_one: {
+        filter: {name: 'yellow'},
+        update: {'$set' => {hex: 'ffff00'}},
+      },
+    },
+    {
+      update_one: {
+        filter: {name: 'purple'},
+        update: {'$set' => {hex: '800080'}},
+      },
+    },
+  ], ordered: true, write_concern: {w: :majority})
 
-- A list of operations to execute.
-- The ``ordered`` option taking a boolean value. Defaults to ``true``.
-- The write concern option. Defaults to the collection's write concern.
+The following example shows how to execute different types of operations
+in the same request:
+
+.. code-block:: ruby
+
+  collection.bulk_write([
+    { insert_one: { x: 1 } },
+    { update_one: {
+      filter: { x: 1 },
+      update: {'$set' => { x: 2 } },
+    } },
+    { replace_one: {
+      filter: { x: 2 },
+      replacement: { x: 3 },
+    } },
+  ], :ordered => true)
+
+The first argument to ``bulk_write`` is the list of operations to perform.
+Each operation must be specified as a hash with exactly one key which is
+the operation name and the operation specification as the corresponding
+value. The supported operations are detailed below. The ``bulk_write`` method
+also accepts the following options:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 80
+
+   * - Option
+     - Description
+   * - ``bypass_document_validation``
+     - ``true`` or ``false``. Whether to bypass document validation.
+   * - ``ordered``
+     - If the ``ordered`` option is set to ``true`` (which is the default),
+       the operations are applied in order and if any operation fails, subsequent
+       operations are not attempted. If the ``ordered`` option is set to ``false``,
+       all specified operations are attempted.
+   * - ``write_concern``
+     - The write concern for the operation, specified as a hash.
 
 Valid bulk write operations are the following:
 
@@ -35,11 +82,11 @@ insert_one
 
 .. code-block:: ruby
 
-    { :insert_one => { :x => 1 } }
+  { insert_one: { x: 1 } }
 
 .. note::
 
-  There is no ``insert_many`` operation. To insert multiple documents,
+  There is no ``insert_many`` bulk operation. To insert multiple documents,
   specify multiple ``insert_one`` operations.
 
 
@@ -48,10 +95,12 @@ update_one
 
 .. code-block:: ruby
 
-    { :update_one => { :filter => { :x => 1 },
-                       :update => { '$set' =>  { :x => 2 } },
-                       :upsert => true } # upsert is optional and defaults to false
-     }
+  { update_one: {
+    filter: { x: 1 },
+    update: { '$set' => { x: 2 } },
+    # upsert is optional and defaults to false
+    upsert: true,
+  } }
 
 
 update_many
@@ -59,29 +108,12 @@ update_many
 
 .. code-block:: ruby
 
-    { :update_many => { :filter => { :x => 1 },
-                        :update => { '$set' =>  { :x => 2 } },
-                        :upsert => true } # upsert is optional and defaults to false
-     }
-
-The following example shows how to pass operations
-to the ``bulk_write`` method.
-
-.. code-block:: ruby
-
-    coll = client['documents']
-    coll.bulk_write([ { :insert_one => { :x => 1 }
-                      },
-                      { :update_one => { :filter => { :x => 1 },
-                                         :update => {'$set' => { :x => 2 } }
-                                       }
-                      },
-                      { :replace_one => { :filter => { :x => 2 },
-                                          :replacement => { :x => 3 }
-                                        }
-                      }
-                    ],
-                    :ordered => true)
+  { update_many: {
+    filter: { x: 1 },
+    update: { '$set' =>  { x: 2 } },
+    # upsert is optional and defaults to false
+    :upsert => true,
+  } }
 
 
 replace_one
@@ -89,10 +121,19 @@ replace_one
 
 .. code-block:: ruby
 
-    { :replace_one => { :filter => { :x => 1 },
-                        :replacement => { :x => 2 },
-                        :upsert => true } # upsert is optional and defaults to false
-     }
+    { replace_one: {
+      filter: { x: 1 },
+      replacement: { x: 2 },
+      # upsert is optional and defaults to false
+      upsert: true,
+    } }
+
+.. note::
+
+  The ``:replace_one`` operation requires that the replacement value is a
+  document. ``:replace_one`` does not recognize MongoDB update operators in
+  the replacement value. In a future release the driver is expected to
+  prohibit using keys beginning with ``$`` in the replacement document.
 
 
 delete_one
@@ -100,7 +141,9 @@ delete_one
 
 .. code-block:: ruby
 
-    { :delete_one => { :filter => { :x => 1 } } }
+  { delete_one: {
+    filter: { x: 1 },
+  } }
 
 
 delete_many
@@ -108,4 +151,19 @@ delete_many
 
 .. code-block:: ruby
 
-    { :delete_many => { :filter => { :x => 1 } } }
+  { delete_many: {
+    filter: { x: 1 },
+  } }
+
+
+Bulk Write Splitting
+====================
+
+The driver allows the application to submit arbitrarily large bulk write
+requests. However, since MongoDB server limits the size of command documents
+(currently this limit is 48 MiB), bulk writes that exceed this limit will be
+split into multiple requests.
+
+When :ref:`client-side encryption <client-side-encryption>` is used, the
+threshold used for bulk write splitting is reduced to allow for overhead in
+the ciphertext.

--- a/lib/mongo/background_thread.rb
+++ b/lib/mongo/background_thread.rb
@@ -20,6 +20,17 @@ module Mongo
   # compatibility reasons. However using these methods outside of the driver
   # is deprecated.
   #
+  # @note Do not start or stop background threads in finalizers. See
+  #   https://jira.mongodb.org/browse/RUBY-2453 and
+  #   https://bugs.ruby-lang.org/issues/16288. When interpreter exits,
+  #   background threads are stopped first and finalizers are invoked next,
+  #   and MRI's internal data structures are basically corrupt at this point
+  #   if threads are being referenced. Prior to interpreter shutdown this
+  #   means threads cannot be stopped by objects going out of scope, but
+  #   most likely the threads hold references to said objects anyway if
+  #   work is being performed thus the objects wouldn't go out of scope in
+  #   the first place.
+  #
   # @api private
   module BackgroundThread
     include Loggable

--- a/lib/mongo/cluster/sdam_flow.rb
+++ b/lib/mongo/cluster/sdam_flow.rb
@@ -178,6 +178,7 @@ class Mongo::Cluster
         raise ArgumentError, "Unknown topology #{topology.class}"
       end
 
+      verify_invariants
       commit_changes
       disconnect_servers
     end
@@ -363,6 +364,9 @@ class Mongo::Cluster
           end
         end
       end
+
+      verify_invariants
+
       added_servers
     end
 
@@ -598,6 +602,16 @@ class Mongo::Cluster
       end
 
       @previous_server_descriptions != server_descriptions
+    end
+
+    def verify_invariants
+      if Mongo::Lint.enabled?
+        if cluster.topology.single?
+          if cluster.servers_list.length > 1
+            raise Mongo::Error::LintError, "Trying to create a single topology with multiple servers: #{cluster.servers_list}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -593,6 +593,8 @@ module Mongo
     # @param [ Array<Hash> ] documents The documents to insert.
     # @param [ Hash ] options The insert options.
     #
+    # @option options [ true | false ] :ordered Whether the operations
+    #   should be executed in order.
     # @option options [ Session ] :session The session to use for the operation.
     #
     # @return [ Result ] The database response wrapper.

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -321,8 +321,20 @@ module Mongo
 
     # Get the Grid "filesystem" for this database.
     #
-    # @example Get the GridFS.
-    #   database.fs
+    # @param [ Hash ] options The GridFS options.
+    #
+    # @option options [ String ] :bucket_name The prefix for the files and chunks
+    #   collections.
+    # @option options [ Integer ] :chunk_size Override the default chunk
+    #   size.
+    # @option options [ String ] :fs_name The prefix for the files and chunks
+    #   collections.
+    # @option options [ String ] :read The read preference.
+    # @option options [ Session ] :session The session to use.
+    # @option options [ Hash ] :write Deprecated. Equivalent to :write_concern
+    #   option.
+    # @option options [ Hash ] :write_concern The write concern options.
+    #   Can be :w => Integer|String, :fsync => Boolean, :j => Boolean.
     #
     # @return [ Grid::FSBucket ] The GridFS for the database.
     #

--- a/lib/mongo/operation/parallel_scan/command.rb
+++ b/lib/mongo/operation/parallel_scan/command.rb
@@ -37,8 +37,7 @@ module Mongo
               read_concern)
           end
           sel[:maxTimeMS] = max_time_ms if max_time_ms
-          update_selector_for_read_pref(sel, connection)
-          sel
+          add_read_preference_legacy(sel, connection)
         end
 
         def message(connection)

--- a/lib/mongo/operation/shared/sessions_supported.rb
+++ b/lib/mongo/operation/shared/sessions_supported.rb
@@ -176,7 +176,7 @@ module Mongo
           # required to only be sent when a non-mode field (i.e. tag_sets)
           # is present, but this causes wrong behavior (DRIVERS-1642).
           if read
-            doc = read.to_doc
+            doc = read.to_mongos
             if doc
               sel['$readPreference'] = doc
             end

--- a/lib/mongo/operation/shared/sessions_supported.rb
+++ b/lib/mongo/operation/shared/sessions_supported.rb
@@ -171,9 +171,10 @@ module Mongo
         elsif connection.description.mongos?
           # When server is a mongos:
           # - $readPreference is never sent when mode is 'primary'
-          # - When mode is 'secondaryPreferred' $readPreference is only sent
-          #   when a non-mode field (i.e. tag_sets) is present
           # - Otherwise $readPreference is sent
+          # When mode is 'secondaryPreferred' $readPreference is currently
+          # required to only be sent when a non-mode field (i.e. tag_sets)
+          # is present, but this causes wrong behavior (DRIVERS-1642).
           if read
             doc = read.to_mongos
             if doc

--- a/lib/mongo/protocol/msg.rb
+++ b/lib/mongo/protocol/msg.rb
@@ -43,8 +43,8 @@ module Mongo
       #   Msg.new([:more_to_come], {}, { ismaster: 1 },
       #           { type: 1, payload: { identifier: 'documents', sequence: [..] } })
       #
-      # @param [ Array<Symbol> ] flags The flag bits. Current supported values
-      #   are :more_to_come and :checksum_present.
+      # @param [ Array<Symbol> ] flags The flag bits. Currently supported
+      #   values are :more_to_come and :checksum_present.
       # @param [ Hash ] options The options.
       # @param [ BSON::Document, Hash ] main_document The document that will
       #   become the payload type 0 section. Can contain global args as they

--- a/lib/mongo/protocol/query.rb
+++ b/lib/mongo/protocol/query.rb
@@ -46,18 +46,18 @@ module Mongo
       # @example Find all user ids.
       #   Query.new('xgen', 'users', {}, :fields => {:id => 1})
       #
-      # @param database [String, Symbol] The database to query.
-      # @param collection [String, Symbol] The collection to query.
-      # @param selector [Hash] The query selector.
-      # @param options [Hash] The additional query options.
+      # @param [ String, Symbol ] database The database to query.
+      # @param [ String, Symbol ] collection The collection to query.
+      # @param [ Hash ] selector The query selector.
+      # @param [ Hash ] options The additional query options.
       #
-      # @option options :project [Hash] The projection.
-      # @option options :skip [Integer] The number of documents to skip.
-      # @option options :limit [Integer] The number of documents to return.
-      # @option options :flags [Array] The flags for the query message.
-      #
-      #   Supported flags: +:tailable_cursor+, +:slave_ok+, +:oplog_replay+,
-      #   +:no_cursor_timeout+, +:await_data+, +:exhaust+, +:partial+
+      # @option options [ Array<Symbol> ] :flags The flag bits.
+      #   Currently supported values are :await_data, :exhaust,
+      #   :no_cursor_timeout, :oplog_replay, :partial, :slave_ok,
+      #   :tailable_cursor.
+      # @option options [ Integer ] :limit The number of documents to return.
+      # @option options [ Hash ] :project The projection.
+      # @option options [ Integer ] :skip The number of documents to skip.
       def initialize(database, collection, selector, options = {})
         @database = database
         @namespace = "#{database}.#{collection}"

--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -272,19 +272,6 @@ module Mongo
       @connected
     end
 
-    # When the server is flagged for garbage collection, stop the monitor
-    # thread.
-    #
-    # @example Finalize the object.
-    #   Server.finalize(monitor)
-    #
-    # @param [ Server::Monitor ] monitor The server monitor.
-    #
-    # @since 2.2.0
-    def self.finalize(monitor)
-      proc { monitor.stop! }
-    end
-
     # Start monitoring the server.
     #
     # Used internally by the driver to add a server to a cluster
@@ -297,7 +284,6 @@ module Mongo
         Monitoring::Event::ServerOpening.new(address, cluster.topology)
       )
       if options[:monitoring_io] != false
-        ObjectSpace.define_finalizer(self, self.class.finalize(monitor))
         monitor.run!
       end
     end

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -684,8 +684,6 @@ module Mongo
       # @return [ Proc ] The Finalizer.
       def self.finalize(available_connections, pending_connections, populator)
         proc do
-          populator.stop!
-
           available_connections.each do |connection|
             connection.disconnect!(reason: :pool_closed)
           end

--- a/lib/mongo/server_selector/secondary_preferred.rb
+++ b/lib/mongo/server_selector/secondary_preferred.rb
@@ -86,13 +86,8 @@ module Mongo
       #
       # @since 2.0.0
       def to_mongos
-        if tag_sets.empty? && max_staleness.nil? && hedge.nil?
-          # The server preference is not sent to mongos as part of the query
-          # selector if there are no tag sets, for maximum backwards compatibility.
-          nil
-        else
-          to_doc
-        end
+        # Always send the read preference to mongos: DRIVERS-1642.
+        to_doc
       end
 
       private

--- a/lib/mongo/srv/monitor.rb
+++ b/lib/mongo/srv/monitor.rb
@@ -59,11 +59,6 @@ module Mongo
       #   records' TTL values.
       attr_reader :last_result
 
-      def start!
-        super
-        ObjectSpace.define_finalizer(self, self.class.finalize(@thread))
-      end
-
       private
 
       def do_work
@@ -95,12 +90,6 @@ module Mongo
         end
 
         @cluster.set_server_list(last_result.address_strs)
-      end
-
-      def self.finalize(thread)
-        Proc.new do
-          thread.kill
-        end
       end
 
       def scan_interval

--- a/spec/integration/sdam_error_handling_spec.rb
+++ b/spec/integration/sdam_error_handling_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'SDAM error handling' do
-  clean_slate_for_all
+  clean_slate
 
   after do
     # Close all clients after every test to avoid leaking expectations into

--- a/spec/integration/sdam_events_spec.rb
+++ b/spec/integration/sdam_events_spec.rb
@@ -67,10 +67,8 @@ describe 'SDAM events' do
         started_events.length.should <= 10
 
         succeeded_events = subscriber.select_succeeded_events(Mongo::Monitoring::Event::ServerHeartbeatSucceeded)
-        # Since we gracefully close the client, we expect each heartbeat
-        # to complete.
         started_events.length.should > 1
-        (succeeded_events.length-1..succeeded_events.length).should include(started_events.length)
+        (succeeded_events.length..succeeded_events.length+1).should include(started_events.length)
       end
     end
 
@@ -109,9 +107,9 @@ describe 'SDAM events' do
         # There may be in-flight ismasters that don't complete, both
         # regular and awaited.
         started_awaited.length.should > 1
-        (succeeded_awaited.length-1..succeeded_awaited.length).should include(started_awaited.length)
+        (succeeded_awaited.length..succeeded_awaited.length+1).should include(started_awaited.length)
         started_regular.length.should > 1
-        (succeeded_regular.length-1..succeeded_regular.length).should include(started_regular.length)
+        (succeeded_regular.length..succeeded_regular.length+1).should include(started_regular.length)
       end
     end
   end

--- a/spec/integration/secondary_reads_spec.rb
+++ b/spec/integration/secondary_reads_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe 'Secondary reads' do
+  before do
+    root_authorized_client.use('sr')['secondary_reads'].drop
+    root_authorized_client.use('sr')['secondary_reads'].insert_one(test: 1)
+  end
+
+  shared_examples 'performs reads as per read preference' do
+
+    %i(primary primary_preferred).each do |mode|
+
+      context mode.inspect do
+
+        let(:client) do
+          root_authorized_client.with(read: {mode: mode}).use('sr')
+        end
+
+        it 'reads from primary' do
+          start_stats = get_read_counters
+
+          30.times do
+            client['secondary_reads'].find.to_a
+          end
+
+          end_stats = get_read_counters
+
+          end_stats[:secondary].should be_within(10).of(start_stats[:secondary])
+          end_stats[:primary].should >= start_stats[:primary] + 30
+        end
+      end
+    end
+
+    %i(secondary secondary_preferred).each do |mode|
+
+      context mode.inspect do
+        let(:client) do
+          root_authorized_client.with(read: {mode: mode}).use('sr')
+        end
+
+        it 'reads from secondaries' do
+          start_stats = get_read_counters
+
+          30.times do
+            client['secondary_reads'].find.to_a
+          end
+
+          end_stats = get_read_counters
+
+          end_stats[:primary].should be_within(10).of(start_stats[:primary])
+          end_stats[:secondary].should >= start_stats[:secondary] + 30
+        end
+      end
+    end
+  end
+
+  context 'replica set' do
+    require_topology :replica_set
+
+    include_examples 'performs reads as per read preference'
+  end
+
+  context 'sharded cluster' do
+    require_topology :sharded
+
+    include_examples 'performs reads as per read preference'
+  end
+
+  def get_read_counters
+    client = ClientRegistry.instance.global_client('root_authorized')
+    addresses = []
+    if client.cluster.sharded?
+      doc = client.use('admin').command(listShards: 1).documents.first
+      doc['shards'].each do |shard|
+        addresses += shard['host'].split('/').last.split(',')
+      end
+    else
+      client.cluster.servers.each do |server|
+        next unless server.primary? || server.secondary?
+        addresses << server.address.seed
+      end
+    end
+    stats = Hash.new(0)
+    addresses.each do |address|
+      ClientRegistry.instance.new_local_client(
+        [address],
+        SpecConfig.instance.all_test_options.merge(connect: :direct),
+      ) do |c|
+        server = c.cluster.servers.first
+        next unless server.primary? || server.secondary?
+        stat = c.command(serverStatus: 1).documents.first
+        queries = stat['opcounters']['query']
+        if server.primary?
+          stats[:primary] += queries
+        else
+          stats[:secondary] += queries
+        end
+      end
+    end
+    stats
+  end
+end

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -274,27 +274,11 @@ describe Mongo::Cluster do
 
   describe '#add' do
 
-    context 'when topology is Single' do
-
-      let(:cluster) { cluster_with_semaphore }
-
-      let(:topology) do
-        Mongo::Cluster::Topology::Single.new({}, cluster)
-      end
-
-      before do
-        cluster.add('a')
-      end
-
-      it 'does not add discovered servers to the cluster' do
-        expect(cluster.servers[0].address.seed).to_not eq('a')
-      end
-    end
-
     context 'topology is Sharded' do
+      require_topology :sharded
 
       let(:topology) do
-        Mongo::Cluster::Topology::Single.new({}, cluster)
+        Mongo::Cluster::Topology::Sharded.new({}, cluster)
       end
 
       before do

--- a/spec/mongo/index/view_spec.rb
+++ b/spec/mongo/index/view_spec.rb
@@ -305,7 +305,8 @@ describe Mongo::Index::View do
                     { key: { testing: -1 }, unique: true },
                     { commit_quorum: 'unsupported-value' }
                   )
-                end.to raise_error(Mongo::Error::OperationFailure, /Commit quorum cannot be satisfied with the current replica set configuration/)
+                # 4.4.4 changed the text of the error message
+                end.to raise_error(Mongo::Error::OperationFailure, /Commit quorum cannot be satisfied with the current replica set configuration|No write concern mode named 'unsupported-value' found in replica set configuration/)
               end
             end
           end
@@ -964,7 +965,8 @@ describe Mongo::Index::View do
           it 'raises an exception' do
             expect do
               view.create_one({ 'x' => 1 }, commit_quorum: 'unsupported-value')
-            end.to raise_error(Mongo::Error::OperationFailure, /Commit quorum cannot be satisfied with the current replica set configuration/)
+            # 4.4.4 changed the text of the error message
+            end.to raise_error(Mongo::Error::OperationFailure, /Commit quorum cannot be satisfied with the current replica set configuration|No write concern mode named 'unsupported-value' found in replica set configuration/)
           end
         end
       end

--- a/spec/mongo/operation/read_preference_legacy_spec.rb
+++ b/spec/mongo/operation/read_preference_legacy_spec.rb
@@ -46,10 +46,10 @@ describe Mongo::Operation::ReadPreferenceSupported do
     end
   end
 
-  describe '#add_slave_ok_flag_maybe' do
+  describe '#add_slave_ok_flag?' do
 
     let(:actual) do
-      operation.send(:add_slave_ok_flag_maybe, operation.send(:options), connection)
+      operation.send(:add_slave_ok_flag?, connection)
     end
 
     shared_examples_for 'sets the slave_ok flag as expected' do
@@ -60,9 +60,7 @@ describe Mongo::Operation::ReadPreferenceSupported do
 
     shared_examples_for 'never sets slave_ok' do
 
-      let(:expected) do
-        { }
-      end
+      let(:expected) { false }
 
       context 'when no read preference is specified' do
         let(:read_pref) { Mongo::ServerSelector.get }
@@ -85,9 +83,7 @@ describe Mongo::Operation::ReadPreferenceSupported do
 
     shared_examples_for 'always sets slave_ok' do
 
-      let(:expected) do
-        { :flags => [ :slave_ok ] }
-      end
+      let(:expected) { true }
 
       context 'when no read preference is specified' do
         let(:read_pref) { Mongo::ServerSelector.get }
@@ -114,9 +110,7 @@ describe Mongo::Operation::ReadPreferenceSupported do
 
         let(:read_pref) { Mongo::ServerSelector.get }
 
-        let(:expected) do
-          { }
-        end
+        let(:expected) { false }
 
         it_behaves_like 'sets the slave_ok flag as expected'
       end
@@ -127,9 +121,7 @@ describe Mongo::Operation::ReadPreferenceSupported do
 
           let(:read_pref) { Mongo::ServerSelector.get(:mode => :secondary) }
 
-          let(:expected) do
-            { :flags => [ :slave_ok ] }
-          end
+          let(:expected) { true }
 
           it_behaves_like 'sets the slave_ok flag as expected'
         end
@@ -138,9 +130,7 @@ describe Mongo::Operation::ReadPreferenceSupported do
 
           let(:read_pref) { Mongo::ServerSelector.get(:mode => :primary) }
 
-          let(:expected) do
-            { }
-          end
+          let(:expected) { false }
 
           it_behaves_like 'sets the slave_ok flag as expected'
         end
@@ -206,7 +196,7 @@ describe Mongo::Operation::ReadPreferenceSupported do
     end
   end
 
-  describe '#update_selector_for_read_pref' do
+  describe '#add_read_preference_legacy' do
 
     let(:read_pref) do
       Mongo::ServerSelector.get(:mode => mode)
@@ -215,7 +205,7 @@ describe Mongo::Operation::ReadPreferenceSupported do
     # Behavior of sending $readPreference is the same regardless of topology.
     shared_examples_for '$readPreference in the command' do
       let(:actual) do
-        operation.send(:update_selector_for_read_pref, operation.send(:selector), connection)
+        operation.send(:add_read_preference_legacy, operation.send(:selector), connection)
       end
 
       let(:expected_read_preference) do

--- a/spec/mongo/operation/read_preference_op_msg_spec.rb
+++ b/spec/mongo/operation/read_preference_op_msg_spec.rb
@@ -175,13 +175,13 @@ describe Mongo::Operation::SessionsSupported do
         let(:tag_sets) { nil }
 
         context 'without tag_sets specified' do
-          it_behaves_like 'does not modify selector'
+          it_behaves_like 'adds read preference'
         end
 
         context 'with empty tag_sets' do
           let(:tag_sets) { [] }
 
-          it_behaves_like 'does not modify selector'
+          it_behaves_like 'adds read preference'
         end
 
         context 'with tag_sets specified' do
@@ -256,7 +256,7 @@ describe Mongo::Operation::SessionsSupported do
           let(:hedge) { nil }
 
           context 'when tag_sets and hedge are not specified' do
-            it_behaves_like 'does not modify selector'
+            it_behaves_like 'adds read preference'
           end
 
           context 'when tag_sets are specified' do

--- a/spec/mongo/server/app_metadata_shared.rb
+++ b/spec/mongo/server/app_metadata_shared.rb
@@ -8,14 +8,40 @@ shared_examples 'app metadata document' do
     document[:client][:driver][:version].should == Mongo::VERSION
   end
 
-  it 'includes operating system information' do
-    document[:client][:os][:type].should == 'linux'
-    if BSON::Environment.jruby? || RUBY_VERSION >= '3.0'
-      document[:client][:os][:name].should == 'linux'
-    else
-      document[:client][:os][:name].should == 'linux-gnu'
+  context 'linux' do
+    before(:all) do
+      unless SpecConfig.instance.linux?
+        skip "Linux required, we have #{RbConfig::CONFIG['host_os']}"
+      end
     end
-    document[:client][:os][:architecture].should == 'x86_64'
+
+    it 'includes operating system information' do
+      document[:client][:os][:type].should == 'linux'
+      if BSON::Environment.jruby? || RUBY_VERSION >= '3.0'
+        document[:client][:os][:name].should == 'linux'
+      else
+        document[:client][:os][:name].should == 'linux-gnu'
+      end
+      document[:client][:os][:architecture].should == 'x86_64'
+    end
+  end
+
+  context 'macos' do
+    before(:all) do
+      unless SpecConfig.instance.macos?
+        skip "MacOS required, we have #{RbConfig::CONFIG['host_os']}"
+      end
+    end
+
+    it 'includes operating system information' do
+      document[:client][:os][:type].should == 'darwin'
+      if BSON::Environment.jruby?
+        document[:client][:os][:name].should == 'darwin'
+      else
+        document[:client][:os][:name].should =~ /darwin\d+/
+      end
+      document[:client][:os][:architecture].should == 'x86_64'
+    end
   end
 
   context 'mri' do

--- a/spec/mongo/server_selector/secondary_preferred_spec.rb
+++ b/spec/mongo/server_selector/secondary_preferred_spec.rb
@@ -78,8 +78,8 @@ describe Mongo::ServerSelector::SecondaryPreferred do
 
     context 'tag sets not provided' do
 
-      it 'returns nil' do
-        expect(selector.to_mongos).to be_nil
+      it 'returns secondaryPreferred' do
+        selector.to_mongos.should == {mode: 'secondaryPreferred'}
       end
     end
 
@@ -89,8 +89,8 @@ describe Mongo::ServerSelector::SecondaryPreferred do
         { :mode => 'secondaryPreferred' }
       end
 
-      it 'returns nil' do
-        expect(selector.to_mongos).to be_nil
+      it 'returns secondaryPreferred' do
+        selector.to_mongos.should == {mode: 'secondaryPreferred'}
       end
     end
 
@@ -120,8 +120,8 @@ describe Mongo::ServerSelector::SecondaryPreferred do
     context 'hedge not provided' do
       let(:hedge) { nil }
 
-      it 'returns nil' do
-        expect(selector.to_mongos).to be_nil
+      it 'returns secondaryPreferred' do
+        selector.to_mongos.should == {mode: 'secondaryPreferred'}
       end
     end
 

--- a/spec/runners/transactions/operation.rb
+++ b/spec/runners/transactions/operation.rb
@@ -191,8 +191,19 @@ module Mongo
 
       def assert_event_count(client, context)
         events = _select_events(context)
-        unless events.length == arguments['count']
-          raise "Exppected #{arguments['count']} #{arguments['event']} events, but have #{events.length}"
+        if arguments['event'] == 'ServerMarkedUnknownEvent'
+          # We publish SDAM events from both regular and push monitors.
+          # This means sometimes there are two ServerMarkedUnknownEvent
+          # events published for the same server transition.
+          # Allow actual event count to be at least the expected event count
+          # in case there are multiple transitions in a single test.
+          unless events.length >= arguments['count']
+            raise "Expected #{arguments['count']} #{arguments['event']} events, but have #{events.length}"
+          end
+        else
+          unless events.length == arguments['count']
+            raise "Expected #{arguments['count']} #{arguments['event']} events, but have #{events.length}"
+          end
         end
       end
 

--- a/spec/solo/clean_exit_spec.rb
+++ b/spec/solo/clean_exit_spec.rb
@@ -1,0 +1,21 @@
+require 'mongo'
+
+describe 'Clean exit' do
+
+  before(:all) do
+    unless %w(1 true yes).include?(ENV['SOLO'])
+      skip 'Set SOLO=1 in environment to run solo tests'
+    end
+  end
+
+  context 'with SRV URI' do
+    let(:uri) do
+      'mongodb+srv://test1.test.build.10gen.cc/?tls=false'
+    end
+
+    it 'exits cleanly' do
+      client = Mongo::Client.new(uri)
+      client.database.collection_names.to_a
+    end
+  end
+end

--- a/spec/support/client_registry.rb
+++ b/spec/support/client_registry.rb
@@ -188,10 +188,14 @@ class ClientRegistry
   end
   private :new_global_client
 
-  def new_local_client(*args)
-    Mongo::Client.new(*args).tap do |client|
-      @lock.synchronize do
-        @local_clients << client
+  def new_local_client(*args, &block)
+    if block_given?
+      Mongo::Client.new(*args, &block)
+    else
+      Mongo::Client.new(*args).tap do |client|
+        @lock.synchronize do
+          @local_clients << client
+        end
       end
     end
   end

--- a/spec/support/client_registry_macros.rb
+++ b/spec/support/client_registry_macros.rb
@@ -1,9 +1,9 @@
 module ClientRegistryMacros
-  def new_local_client(address, options=nil)
-    ClientRegistry.instance.new_local_client(address, options)
+  def new_local_client(address, options=nil, &block)
+    ClientRegistry.instance.new_local_client(address, options, &block)
   end
 
-  def new_local_client_nmio(address, options=nil)
+  def new_local_client_nmio(address, options=nil, &block)
     # Avoid type converting options.
     base_options = {monitoring_io: false}
     if BSON::Document === options || options&.keys&.any? { |key| String === key }
@@ -14,7 +14,7 @@ module ClientRegistryMacros
     else
       base_options
     end
-    new_local_client(address, options)
+    new_local_client(address, options, &block)
   end
 
   def close_local_clients

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -110,6 +110,14 @@ class SpecConfig
     !!(RUBY_PLATFORM =~ /\bjava\b/)
   end
 
+  def linux?
+    !!(RbConfig::CONFIG['host_os'].downcase =~ /\blinux/)
+  end
+
+  def macos?
+    !!(RbConfig::CONFIG['host_os'].downcase =~ /\bdarwin/)
+  end
+
   def platform
     RUBY_PLATFORM
   end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -364,6 +364,10 @@ EOT
     end
   end
 
+  def auth?
+    x509_auth? || user
+  end
+
   # Option hashes
 
   def auth_options

--- a/spec/support/spec_setup.rb
+++ b/spec/support/spec_setup.rb
@@ -8,38 +8,50 @@ class SpecSetup
       return
     end
 
-    # Create the root user administrator as the first user to be added to the
-    # database. This user will need to be authenticated in order to add any
-    # more users to any other databases.
-    begin
-      create_user(admin_unauthorized_client, SpecConfig.instance.root_user)
-    rescue Mongo::Error::OperationFailure => e
-      # When testing a cluster that requires auth, root user is already set up
-      # and it is not creatable without auth.
-      # Seems like every mongodb version has its own error message
-      # for trying to make a user when not authenticated,
-      # and prior to 4.0 or so the codes are supposedly not reliable either.
-      # In order: 4.0, 3.6, 3.4 through 2.6
-      if e.message =~ /command createUser requires authentication|there are no users authenticated|not authorized on admin to execute command.*createUser/
-        # However, if the cluster is configured to require auth but
-        # test suite has wrong credentials, then admin_authorized_test_client
-        # won't be authenticated and the following line will raise an
-        # exception
-        if admin_authorized_test_client.with(database: 'admin').database.users.info(SpecConfig.instance.root_user.name).any?
-          warn "Skipping root user creation, likely auth is enabled on cluster"
-        else
-          raise
+    with_client do |client|
+      # For historical reasons, the test suite always uses
+      # password-authenticated users, even when authentication is not
+      # requested in the configuration. When authentication is requested
+      # and password authentication is used (i.e., not x509 and not kerberos),
+      # a suitable user already exists (it's the one specified in the URI)
+      # and no additional users are needed. In other cases, including x509
+      # auth and kerberos, create the "root user".
+      # TODO redo the test suite so that this password-authenticated root user
+      # is not required and the test suite uses whichever user is specified
+      # in the URI, which could be none.
+      if !SpecConfig.instance.auth? || SpecConfig.instance.x509_auth?
+        # Create the root user administrator as the first user to be added to the
+        # database. This user will need to be authenticated in order to add any
+        # more users to any other databases.
+        begin
+          create_user(client, SpecConfig.instance.root_user)
+        rescue Mongo::Error::OperationFailure => e
+          # When testing a cluster that requires auth, root user is already set up
+          # and it is not creatable without auth.
+          # Seems like every mongodb version has its own error message
+          # for trying to make a user when not authenticated,
+          # and prior to 4.0 or so the codes are supposedly not reliable either.
+          # In order: 4.0, 3.6, 3.4 through 2.6
+          if e.message =~ /command createUser requires authentication|there are no users authenticated|not authorized on admin to execute command.*createUser/
+            # However, if the cluster is configured to require auth but
+            # test suite has wrong credentials, then admin_authorized_test_client
+            # won't be authenticated and the following line will raise an
+            # exception
+            if client.use('admin').database.users.info(SpecConfig.instance.root_user.name).any?
+              warn "Skipping root user creation, likely auth is enabled on cluster"
+            else
+              raise
+            end
+          else
+            raise
+          end
         end
-      else
-        raise
       end
-    end
-    admin_unauthorized_client.close
 
-    # Adds the test user to the test database with permissions on all
-    # databases that will be used in the test suite.
-    create_user(admin_authorized_test_client, SpecConfig.instance.test_user)
-    admin_authorized_test_client.close
+      # Adds the test user to the test database with permissions on all
+      # databases that will be used in the test suite.
+      create_user(client, SpecConfig.instance.test_user)
+    end
   end
 
   def create_user(client, user)
@@ -56,15 +68,13 @@ class SpecSetup
     end
   end
 
-  def admin_unauthorized_client
-    ClientRegistry.instance.global_client('admin_unauthorized').with(
-      socket_timeout: 5, connect_timeout: 5,
-    )
-  end
-
-  def admin_authorized_test_client
-    ClientRegistry.instance.global_client('root_authorized').with(
-      socket_timeout: 5, connect_timeout: 5,
+  def with_client(&block)
+    Mongo::Client.new(
+      SpecConfig.instance.addresses,
+      SpecConfig.instance.all_test_options.merge(
+        socket_timeout: 5, connect_timeout: 5,
+      ),
+      &block
     )
   end
 end


### PR DESCRIPTION
This merges upstream https://github.com/mongodb/mongo-ruby-driver `2.14-stable` branch into our fork

and reverts https://github.com/braze-inc/mongo-ruby-driver/commit/065a7122fc86e8d7a9973a7574488aa232204ffb (the change for https://github.com/Appboy/platform/pull/30863) since upstream fixed the problem in a different way - https://github.com/mongodb/mongo-ruby-driver/pull/2200